### PR TITLE
Small revamp of alias support

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -17,6 +17,10 @@ CycoD supports the following commands:
 | `chat` | Start a chat session (default) |
 | `config` | Manage configuration settings |
 | `github login` | Authenticate with GitHub Copilot |
+| `alias list` | List all available aliases |
+| `alias get <name>` | View the content of a specific alias |
+| `alias add <name> <content>` | Add a new raw alias without syntax validation |
+| `alias delete <name>` | Delete an alias |
 | `version` | Display version information |
 | `help` | Display help information |
 
@@ -141,14 +145,32 @@ This saves the conversation in a more human-readable format.
 
 ### Creating an Alias
 
+There are two ways to create aliases:
+
+#### 1. Using --save-alias (for validated aliases)
+
 ```bash
 cycod --system-prompt "You are a helpful coding assistant." --save-alias coding-helper
 ```
 
-Using the alias:
+This creates an alias with syntax validation - all arguments must be valid at creation time.
+
+#### 2. Using the alias add command (for raw aliases)
 
 ```bash
+cycod alias add template-alias --content "--system-prompt \"You are a template\" --instruction"
+```
+
+This creates a raw alias without syntax validation - perfect for templates or partial commands.
+
+Using the aliases:
+
+```bash
+# Using a validated alias
 cycod --coding-helper --input "Help me write a Python function to sort a list of dictionaries by a specific key."
+
+# Using a raw alias
+cycod --template-alias "Write a function to do X"
 ```
 
 ### Managing Token Usage
@@ -260,6 +282,15 @@ cycod --python-expert --input "Explain decorators in Python" --output-chat-histo
 ```
 
 This applies all options from the `python-expert` alias and then adds the additional options specified.
+
+### Combining Multiple Aliases
+
+You can use multiple aliases in a single command (especially useful with raw aliases):
+
+```bash
+# Combine a system prompt alias with a specific instruction template
+cycod --python-expert --code-review-template "def add(a, b): return a + b"
+```
 
 ### Using Chat Commands
 

--- a/src/common/CommandLine/CommandLineOptions.cs
+++ b/src/common/CommandLine/CommandLineOptions.cs
@@ -1,3 +1,4 @@
+using NuGet.Frameworks;
 using System.Text.RegularExpressions;
 
 public class CommandLineOptions
@@ -90,12 +91,12 @@ public class CommandLineOptions
     }
 
     virtual protected bool TryParseOtherCommandOptions(Command? command, string[] args, ref int i, string arg)
-	{
-		return false;
+    {
+        return false;
     }
 
     virtual protected bool TryParseOtherCommandArg(Command? command, string arg)
-	{
+    {
         return false;
     }
 
@@ -103,7 +104,7 @@ public class CommandLineOptions
     {
         return args.SelectMany(arg => ExpandedInput(arg));
     }
-    
+
     protected IEnumerable<string> ExpandedInput(string input)
     {
         return input.StartsWith("@@")
@@ -146,6 +147,16 @@ public class CommandLineOptions
         Command? command = null;
 
         var args = this.AllOptions = allInputs.ToArray();
+
+        // Make a pass to deference all aliases.
+        for (int i = 0; i < args.Count(); i++)
+        {
+            if (args[i].StartsWith("--"))
+            {
+                TryParseAliasOptions(ref command, ref args, ref i, args[i].Substring(2));
+            }
+        }
+
         for (int i = 0; i < args.Count(); i++)
         {
             var parsed = TryParseInputOptions(ref command, args, ref i, args[i]);
@@ -192,7 +203,7 @@ public class CommandLineOptions
             var arguments = allowMultipleArgs
                 ? GetInputOptionArgs(i + 1, args).ToList()
                 : GetInputOptionArgs(i + 1, args, max: 1).ToList();
-            
+
             if (arguments.Count == 0)
             {
                 throw new CommandLineException($"Missing value for {arg}");
@@ -212,11 +223,11 @@ public class CommandLineOptions
                 ConfigStore.Instance.SetFromCommandLine(settingName!, arguments);
                 ConsoleHelpers.WriteDebugLine($"Set known setting from CLI: {settingName} = [{string.Join(", ", arguments)}]");
             }
-            
+
             i += arguments.Count;
             return true;
         }
-        
+
         return false;
     }
 
@@ -233,12 +244,6 @@ public class CommandLineOptions
         var needNewCommand = command == null;
         if (needNewCommand)
         {
-            if (arg.StartsWith("--"))
-            {
-                var parsedAsAlias = TryParseAliasOptions(ref command, args, ref i, arg.Substring(2));
-                if (parsedAsAlias) return true;
-            }
-
             var commandName = PeekCommandName(args, i);
             var partialCommandNeedsHelp = CheckPartialCommandNeedsHelp(commandName);
             if (partialCommandNeedsHelp)
@@ -284,16 +289,17 @@ public class CommandLineOptions
         }
         else if (arg.StartsWith("--"))
         {
-            parsedOption = TryParseAliasOptions(ref command, args, ref i, arg.Substring(2));
+            parsedOption = TryParseAliasOptions(ref command, ref args, ref i, arg.Substring(2));
         }
         else if (command is HelpCommand helpCommand)
         {
             this.HelpTopic = $"{this.HelpTopic} {arg}".Trim();
             parsedOption = true;
         }
-        else if (TryParseOtherCommandArg(command, arg))
+
+        if (!parsedOption && TryParseOtherCommandArg(command, arg))
         {
-		    parsedOption = true;
+            parsedOption = true;
         }
 
         if (!parsedOption)
@@ -304,24 +310,22 @@ public class CommandLineOptions
         return parsedOption;
     }
 
-    protected bool TryParseAliasOptions(ref Command? command, string[] args, ref int currentIndex, string alias)
+    protected bool TryParseAliasOptions(ref Command? command, ref string[] args, ref int currentIndex, string alias)
     {
         var aliasFilePath = AliasFileHelpers.FindAliasFile(alias);
         if (aliasFilePath != null && File.Exists(aliasFilePath))
         {
-            var aliasArgs = File.ReadAllLines(aliasFilePath)
+            var aliasLines = File.ReadAllLines(aliasFilePath);
+
+            // If it's a raw alias, skip the first line (metadata)
+            var aliasArgs = aliasLines
                 .Select(x => x.StartsWith('@')
                     ? AtFileHelpers.ExpandAtFileValue(x)
                     : x)
                 .ToArray();
-            for (var j = 0; j < aliasArgs.Length; j++)
-            {
-                var parsed = TryParseInputOptions(ref command, aliasArgs, ref j, aliasArgs[j]);
-                if (!parsed)
-                {
-                    throw new CommandLineException($"Invalid argument in alias file: {aliasArgs[j]}");
-                }
-            }
+
+            args = args.Take(currentIndex).Concat(aliasArgs).Concat(args.Skip(currentIndex + 1)).ToArray();
+
             return true;
         }
         return false;
@@ -514,7 +518,7 @@ public class CommandLineOptions
     protected (string, string) ValidateAssignment(string arg, string? assignment)
     {
         assignment = ValidateString(arg, assignment, "assignment")!;
-        
+
         var parts = assignment.Split('=', 2);
         if (parts.Length != 2)
         {

--- a/src/cycod/CommandLine/CycoDevCommandLineOptions.cs
+++ b/src/cycod/CommandLine/CycoDevCommandLineOptions.cs
@@ -280,18 +280,6 @@ public class CycoDevCommandLineOptions : CommandLineOptions
         {
             command.Scope = ConfigFileScope.Any;
         }
-        else if (command is AliasAddCommand addCommand && arg == "--content")
-        {
-            // Get all arguments until we hit a new option or the end
-            var contentArgs = GetInputOptionArgs(i + 1, args).ToList();
-            if (contentArgs.Count == 0)
-            {
-                throw new CommandLineException("Missing value for --content");
-            }
-            
-            addCommand.Content = string.Join(" ", contentArgs);
-            i += contentArgs.Count;
-        }
         else
         {
             parsed = false;

--- a/src/cycod/CommandLine/CycoDevCommandLineOptions.cs
+++ b/src/cycod/CommandLine/CycoDevCommandLineOptions.cs
@@ -67,6 +67,7 @@ public class CycoDevCommandLineOptions : CommandLineOptions
             "config remove" => new ConfigRemoveCommand(),
             "alias list" => new AliasListCommand(),
             "alias get" => new AliasGetCommand(),
+            "alias add" => new AliasAddCommand(),
             "alias delete" => new AliasDeleteCommand(),
             "prompt list" => new PromptListCommand(),
             "prompt get" => new PromptGetCommand(),
@@ -147,6 +148,21 @@ public class CycoDevCommandLineOptions : CommandLineOptions
         {
             aliasGetCommand.AliasName = arg;
             parsedOption = true;
+        }
+        else if (command is AliasAddCommand aliasAddCommand)
+        {
+            if (string.IsNullOrEmpty(aliasAddCommand.AliasName))
+            {
+                aliasAddCommand.AliasName = arg;
+                parsedOption = true;
+            }
+            else if (string.IsNullOrEmpty(aliasAddCommand.Content))
+            {
+                // Just store the current argument as content
+                // The proper handling of all content will be done in ExecuteAsync
+                aliasAddCommand.Content = arg;
+                parsedOption = true;
+            }
         }
         else if (command is AliasDeleteCommand aliasDeleteCommand && string.IsNullOrEmpty(aliasDeleteCommand.AliasName))
         {
@@ -262,6 +278,18 @@ public class CycoDevCommandLineOptions : CommandLineOptions
         else if (arg == "--any" || arg == "-a")
         {
             command.Scope = ConfigFileScope.Any;
+        }
+        else if (command is AliasAddCommand addCommand && arg == "--content")
+        {
+            // Get all arguments until we hit a new option or the end
+            var contentArgs = GetInputOptionArgs(i + 1, args).ToList();
+            if (contentArgs.Count == 0)
+            {
+                throw new CommandLineException("Missing value for --content");
+            }
+            
+            addCommand.Content = string.Join(" ", contentArgs);
+            i += contentArgs.Count;
         }
         else
         {

--- a/src/cycod/CommandLineCommands/AliasCommands/AliasAddCommand.cs
+++ b/src/cycod/CommandLineCommands/AliasCommands/AliasAddCommand.cs
@@ -1,0 +1,167 @@
+/// <summary>
+/// Command to add a new alias with raw arguments, without syntax validation.
+/// </summary>
+
+using System.Text;
+
+class AliasAddCommand : AliasBaseCommand
+{
+    /// <summary>
+    /// The name of the alias to add.
+    /// </summary>
+    public string? AliasName { get; set; }
+
+    /// <summary>
+    /// The content/arguments for the alias.
+    /// </summary>
+    public string? Content { get; set; }
+
+    /// <summary>
+    /// Constructor initializes the base command.
+    /// </summary>
+    public AliasAddCommand() : base()
+    {
+        Scope = ConfigFileScope.Local;
+    }
+
+    /// <summary>
+    /// Checks if the command is empty (i.e., no alias name or content provided).
+    /// </summary>
+    /// <returns>True if empty, false otherwise.</returns>
+    public override bool IsEmpty()
+    {
+        return string.IsNullOrWhiteSpace(AliasName);
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    /// <returns>The command name.</returns>
+    public override string GetCommandName()
+    {
+        return "alias add";
+    }
+
+    /// <summary>
+    /// Execute the add command.
+    /// </summary>
+    /// <param name="interactive">Whether the command is running in interactive mode.</param>
+    /// <returns>Exit code, 0 for success, non-zero for failure.</returns>
+    public override async Task<object> ExecuteAsync(bool interactive)
+    {
+        return await Task.Run(() =>
+        {
+            if (string.IsNullOrWhiteSpace(AliasName))
+            {
+                ConsoleHelpers.WriteErrorLine("Error: Alias name is required.");
+                return 1;
+            }
+
+            if (string.IsNullOrWhiteSpace(Content))
+            {
+                ConsoleHelpers.WriteErrorLine("Error: Alias content is required. Provide it with as the next parameter after the alias name.");
+                ConsoleHelpers.WriteLine("Example: cycod alias add myalias \"--system-prompt \\\"You are helpful\\\" --instruction\"");
+                return 1;
+            }
+
+            return ExecuteAdd(AliasName, Content, Scope ?? ConfigFileScope.Local);
+        });
+    }
+
+    /// <summary>
+    /// Execute the add command for the specified alias name, content, and scope.
+    /// </summary>
+    /// <param name="aliasName">The name of the alias to add.</param>
+    /// <param name="content">The content for the alias.</param>
+    /// <param name="scope">The scope to save the alias in.</param>
+    /// <returns>Exit code, 0 for success, non-zero for failure.</returns>
+    private int ExecuteAdd(string aliasName, string content, ConfigFileScope scope)
+    {
+        ConsoleHelpers.WriteDebugLine($"ExecuteAdd; aliasName: {aliasName}; scope: {scope}");
+
+        // Check if the alias already exists
+        var existingAliasPath = AliasFileHelpers.FindAliasInScope(aliasName, scope);
+        if (existingAliasPath != null)
+        {
+            ConsoleHelpers.WriteWarningLine($"Warning: Alias '{aliasName}' already exists in the {scope.ToString().ToLower()} scope and will be overwritten.");
+        }
+
+        // Remove any "cycod" executable name if the user accidentally included it
+        if (content.TrimStart().StartsWith("cycod "))
+        {
+            content = content.TrimStart().Substring(6).TrimStart();
+            ConsoleHelpers.WriteWarningLine("Note: 'cycod' prefix removed from alias content (not needed).");
+        }
+
+        var contentLines = TokenizeAliasValue(content);
+
+        // Get the alias directory and ensure it exists
+        var aliasDirectory = AliasFileHelpers.FindAliasDirectoryInScope(scope, create: true)!;
+        var fileName = Path.Combine(aliasDirectory, $"{aliasName}.alias");
+
+        try
+        {
+            // Write the content to the alias file
+            File.WriteAllLines(fileName, contentLines);
+            ConsoleHelpers.WriteLine($"Created alias '{aliasName}' in {scope.ToString().ToLower()} scope.");
+            ConsoleHelpers.WriteLine($"Usage examples:");
+            ConsoleHelpers.WriteLine($"  cycod --{aliasName} [additional arguments]");
+            ConsoleHelpers.WriteLine($"  cycod [arguments] --{aliasName} [more arguments]");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            ConsoleHelpers.WriteErrorLine($"Error creating alias: {ex.Message}");
+            return 1;
+        }
+    }
+
+    public static string[] TokenizeAliasValue(string commandLine)
+    {
+        if (string.IsNullOrWhiteSpace(commandLine))
+            return Array.Empty<string>();
+
+        var args = new List<string>();
+        var currentArg = new StringBuilder();
+        var inQuotes = false;
+
+        for (int i = 0; i < commandLine.Length; i++)
+        {
+            char c = commandLine[i];
+
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (c == '\\' && i + 1 < commandLine.Length && commandLine[i + 1] == '"')
+            {
+                // Handle escaped quotes
+                currentArg.Append('"');
+                i++; // Skip the next character (the quote)
+            }
+            else if (char.IsWhiteSpace(c) && !inQuotes)
+            {
+                // End of current argument
+                if (currentArg.Length > 0)
+                {
+                    args.Add(currentArg.ToString());
+                    currentArg.Clear();
+                }
+
+                // Skip consecutive whitespace
+                while (i + 1 < commandLine.Length && char.IsWhiteSpace(commandLine[i + 1]))
+                    i++;
+            }
+            else
+            {
+                currentArg.Append(c);
+            }
+        }
+
+        // Add final argument if any
+        if (currentArg.Length > 0)
+            args.Add(currentArg.ToString());
+
+        return args.ToArray();
+    }
+}

--- a/src/cycod/Properties/launchSettings.json
+++ b/src/cycod/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "cycod": {
+      "commandName": "Project",
+      "commandLineArgs": "--code \"Tell me a joke\""
+    }
+  }
+}

--- a/src/cycod/assets/help/alias add.txt
+++ b/src/cycod/assets/help/alias add.txt
@@ -1,0 +1,63 @@
+CYCOD ALIAS ADD COMMAND
+
+  Creates a new alias with raw content without syntax validation.
+
+USAGE: cycod alias add ALIAS_NAME --content "CONTENT" [--scope]
+
+DESCRIPTION
+
+  The 'alias add' command creates a new alias that can be used with the --ALIAS_NAME
+  syntax. Unlike aliases created with --save-alias, aliases created with this command
+  don't undergo syntax validation, making them suitable for creating template-like
+  aliases or aliases with incomplete commands.
+
+  The content should be command-line arguments (without the 'cycod' prefix) that will
+  be inserted when the alias is used.
+
+PARAMETERS
+
+  ALIAS_NAME       Name of the alias to create
+
+OPTIONS
+
+  --content        Command-line arguments to include in the alias
+                   Enclose in quotes if it contains spaces or special characters
+
+  SCOPE OPTIONS
+
+    --global, -g   Save in global scope (available to all users)
+    --user, -u     Save in user scope (available to current user in any directory)
+    --local, -l    Save in local scope (current directory) - DEFAULT
+
+EXAMPLES
+
+  # Create a local alias for code prompts
+  cycod alias add code-prompt --content "--add-system-prompt @/prompts/code-system-prompt.md --instruction"
+
+  # Create a user-scoped alias for Python programming
+  cycod alias add python-expert --user --content "--system-prompt \"You are a Python expert\""
+
+  # Create a global alias for Linux administration
+  cycod alias add linux-admin --global --content "--system-prompt \"You are a Linux administrator\""
+
+  # Create an alias from stdin
+  echo "--system-prompt \"Content from stdin\"" | cycod alias add stdin-alias
+
+USAGE EXAMPLES
+
+  # Use the alias with required parameters
+  cycod --code-prompt "Write a sorting algorithm"
+
+  # Use the alias with other options
+  cycod --verbose --code-prompt "Write a sorting algorithm"
+
+  # Place the alias anywhere in the command line
+  cycod --input "Let's talk about" --code-prompt "sorting algorithms"
+
+SEE ALSO
+
+  cycod help alias
+  cycod help alias list
+  cycod help alias get
+  cycod help alias delete
+  cycod help aliases

--- a/src/cycod/assets/help/alias add.txt
+++ b/src/cycod/assets/help/alias add.txt
@@ -2,7 +2,7 @@ CYCOD ALIAS ADD COMMAND
 
   Creates a new alias with raw content without syntax validation.
 
-USAGE: cycod alias add ALIAS_NAME --content "CONTENT" [--scope]
+USAGE: cycod alias add ALIAS_NAME "CONTENT" [--scope]
 
 DESCRIPTION
 
@@ -18,9 +18,7 @@ PARAMETERS
 
   ALIAS_NAME       Name of the alias to create
 
-OPTIONS
-
-  --content        Command-line arguments to include in the alias
+  CONTENT          Command-line arguments to include in the alias
                    Enclose in quotes if it contains spaces or special characters
 
   SCOPE OPTIONS
@@ -32,16 +30,13 @@ OPTIONS
 EXAMPLES
 
   # Create a local alias for code prompts
-  cycod alias add code-prompt --content "--add-system-prompt @/prompts/code-system-prompt.md --instruction"
+  cycod alias add code-prompt "--add-system-prompt @/prompts/code-system-prompt.md --instruction"
 
   # Create a user-scoped alias for Python programming
-  cycod alias add python-expert --user --content "--system-prompt \"You are a Python expert\""
+  cycod alias add python-expert --user "--system-prompt \"You are a Python expert\""
 
   # Create a global alias for Linux administration
-  cycod alias add linux-admin --global --content "--system-prompt \"You are a Linux administrator\""
-
-  # Create an alias from stdin
-  echo "--system-prompt \"Content from stdin\"" | cycod alias add stdin-alias
+  cycod alias add linux-admin --global "--system-prompt \"You are a Linux administrator\""
 
 USAGE EXAMPLES
 

--- a/src/cycod/assets/help/alias.txt
+++ b/src/cycod/assets/help/alias.txt
@@ -4,6 +4,7 @@ CYCOD ALIAS COMMANDS
 
 USAGE: cycod alias list [--scope]
    OR: cycod alias get ALIAS_NAME [--scope]
+   OR: cycod alias add ALIAS_NAME CONTENT [--scope]
    OR: cycod alias delete ALIAS_NAME [--scope]
 
 OPTIONS
@@ -19,11 +20,13 @@ COMMANDS
 
     list            List all available aliases
     get             Display the content of a specific alias
+    add             Create a new alias with raw content (no syntax validation)
     delete          Delete an alias
 
 SEE ALSO
 
   cycod help alias list
   cycod help alias get
+  cycod help alias add
   cycod help alias delete
   cycod help aliases

--- a/src/cycod/cycod.csproj
+++ b/src/cycod/cycod.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.5.0-preview.1.25265.7" />
     <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />

--- a/src/cycod/cycod.csproj
+++ b/src/cycod/cycod.csproj
@@ -38,7 +38,6 @@
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.5.0-preview.1.25265.7" />
     <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.1" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />

--- a/tests/cycod-yaml/cycod-alias-tests.yaml
+++ b/tests/cycod-yaml/cycod-alias-tests.yaml
@@ -1,0 +1,122 @@
+- area: Alias Commands
+  tests:
+  - name: Alias List (empty initially)
+    run: cycod alias list --local
+    expect-regex: |
+      LOCATION: .*[\\/]\.cycod[\\/]aliases \(local\)
+      No aliases found in this scope
+
+  - name: Create Raw Alias with alias add
+    run: cycod alias add test-raw-alias "--system-prompt \"You are a test assistant\" --instruction"
+    expect-regex: |
+      Created alias 'test-raw-alias' in local scope.
+      Usage examples:
+        cycod --test-raw-alias \[additional arguments\]
+        cycod \[arguments\] --test-raw-alias \[more arguments\]
+
+  - name: Create Validated Alias with save-alias
+    run: cycod --system-prompt "You are a validated assistant" --save-alias test-validated-alias
+    expect-regex: |
+      Created alias file: .*[\\/]\.cycod[\\/]aliases[\\/]test-validated-alias\.alias
+      Use: cycod --test-validated-alias \[...\]
+
+  - name: Create Role Alias
+    run: cycod alias add python-expert "--system-prompt \"You are a Python expert\""
+    expect-regex: |
+      Created alias 'python-expert' in local scope.
+
+  - name: Create Template Alias
+    run: cycod alias add code-review "--add-system-prompt \"Review this code:\" --input"
+    expect-regex: |
+      Created alias 'code-review' in local scope.
+
+  - name: Alias List (after creating aliases)
+    run: cycod alias list --local
+    expect-regex: |
+      LOCATION: .*[\\/]\.cycod[\\/]aliases \(local\)
+      code-review
+      python-expert
+      test-raw-alias
+      test-validated-alias
+
+  - name: Alias Get (raw alias)
+    run: cycod alias get test-raw-alias
+    expect-regex: |
+      test-raw-alias
+      ----------------
+      #TYPE=raw
+      --system-prompt "You are a test assistant" --instruction
+      
+      LOCATION: .*[\\/]\.cycod[\\/]aliases[\\/]test-raw-alias\.alias \(local\)
+
+  - name: Alias Get (validated alias)
+    run: cycod alias get test-validated-alias
+    expect-regex: |
+      test-validated-alias
+      ----------------
+      --system-prompt
+      You are a validated assistant
+      
+      LOCATION: .*[\\/]\.cycod[\\/]aliases[\\/]test-validated-alias\.alias \(local\)
+
+  - name: Use Raw Alias with Required Argument
+    run: cycod --test-raw-alias "Write a test" --quiet
+    not-expect-regex: |
+      Error: Invalid argument in alias file
+
+  - name: Use Validated Alias
+    run: cycod --test-validated-alias --input "Hello" --quiet
+    not-expect-regex: |
+      Error: Invalid argument in alias file
+
+  - name: Combine Multiple Aliases
+    run: cycod --python-expert --code-review "def add(a, b): return a + b" --quiet
+    not-expect-regex: |
+      Error: Invalid argument in alias file
+
+  - name: Alias with cycod prefix is handled correctly
+    run: cycod alias add prefix-alias "cycod --system-prompt \"Test with prefix\""
+    expect-regex: |
+      Note: 'cycod' prefix removed from alias content \(not needed\).
+      Created alias 'prefix-alias' in local scope.
+
+  - name: Get Alias with cycod prefix removed
+    run: cycod alias get prefix-alias
+    expect-regex: |
+      prefix-alias
+      ----------------
+      #TYPE=raw
+      --system-prompt "Test with prefix"
+      
+      LOCATION: .*[\\/]\.cycod[\\/]aliases[\\/]prefix-alias\.alias \(local\)
+
+  - name: Alias Delete (raw alias)
+    run: cycod alias delete test-raw-alias
+    expect-regex: |
+      Deleted: .*[\\/]\.cycod[\\/]aliases[\\/]test-raw-alias\.alias
+
+  - name: Alias Delete (validated alias)
+    run: cycod alias delete test-validated-alias
+    expect-regex: |
+      Deleted: .*[\\/]\.cycod[\\/]aliases[\\/]test-validated-alias\.alias
+
+  - name: Alias Delete (prefix alias)
+    run: cycod alias delete prefix-alias
+    expect-regex: |
+      Deleted: .*[\\/]\.cycod[\\/]aliases[\\/]prefix-alias\.alias
+
+  - name: Alias Delete (python-expert)
+    run: cycod alias delete python-expert
+    expect-regex: |
+      Deleted: .*[\\/]\.cycod[\\/]aliases[\\/]python-expert\.alias
+
+  - name: Alias Delete (code-review)
+    run: cycod alias delete code-review
+    expect-regex: |
+      Deleted: .*[\\/]\.cycod[\\/]aliases[\\/]code-review\.alias
+
+  - name: Alias List (after deletion)
+    run: cycod alias list --local
+    expect-regex: |
+      LOCATION: .*[\\/]\.cycod[\\/]aliases \(local\)
+      No aliases found in this scope


### PR DESCRIPTION
Add "alias add" action to enable alias creation without syntax validation to enable use like:

cycod alias add code --user "--add-system-prompt @/prompts/system_code.md --instruction"

and then:

cycod --code "Write me a minivan."