### PR TITLE
Enforce consistent formatting of KnownSettings in yaml files

### DIFF
--- a/src/common/Configuration/KnownSettings.cs
+++ b/src/common/Configuration/KnownSettings.cs
@@ -350,6 +350,28 @@ public static class KnownSettings
     }
     
     /// <summary>
+    /// Gets the canonical form of a known setting key.
+    /// </summary>
+    /// <param name="key">The key to normalize (in any format).</param>
+    /// <returns>The canonical form of the key, or the original key if not found.</returns>
+    public static string GetCanonicalForm(string key)
+    {
+        // First normalize to dot notation
+        var normalized = ToDotNotation(key);
+        
+        // Find the exact match in our known settings (case-insensitive)
+        foreach (var knownSetting in _dotToEnvVarMap.Keys)
+        {
+            if (string.Equals(knownSetting, normalized, StringComparison.OrdinalIgnoreCase))
+            {
+                return knownSetting;
+            }
+        }
+        
+        return normalized;
+    }
+    
+    /// <summary>
     /// Converts a setting name to environment variable format.
     /// </summary>
     /// <param name="key">The setting name in any format.</param>

--- a/src/cycod/CommandLineCommands/ConfigCommands/ConfigClearCommand.cs
+++ b/src/cycod/CommandLineCommands/ConfigCommands/ConfigClearCommand.cs
@@ -29,6 +29,12 @@ class ConfigClearCommand : ConfigBaseCommand
             throw new CommandLineException($"Key cannot be null or empty.");
         }
 
+        // Normalize the key if it's a known setting
+        if (KnownSettings.IsKnown(key))
+        {
+            key = KnownSettings.GetCanonicalForm(key);
+        }
+
         var isFileNameScope = scope == ConfigFileScope.FileName && !string.IsNullOrEmpty(configFileName);
         bool cleared = isFileNameScope
             ? _configStore.Clear(key, configFileName!)

--- a/src/cycod/CommandLineCommands/ConfigCommands/ConfigGetCommand.cs
+++ b/src/cycod/CommandLineCommands/ConfigCommands/ConfigGetCommand.cs
@@ -30,6 +30,12 @@ class ConfigGetCommand : ConfigBaseCommand
             throw new CommandLineException("Error: No key specified.");
         }
 
+        // Normalize the key if it's a known setting
+        if (KnownSettings.IsKnown(key))
+        {
+            key = KnownSettings.GetCanonicalForm(key);
+        }
+
         var isFileNameScope = scope == ConfigFileScope.FileName && !string.IsNullOrEmpty(configFileName);
         var value = isFileNameScope
             ? _configStore.GetFromFileName(key, configFileName!)

--- a/src/cycod/CommandLineCommands/ConfigCommands/ConfigSetCommand.cs
+++ b/src/cycod/CommandLineCommands/ConfigCommands/ConfigSetCommand.cs
@@ -28,6 +28,16 @@ class ConfigSetCommand : ConfigBaseCommand
         if (string.IsNullOrWhiteSpace(key)) throw new CommandLineException($"Error: No key specified.");
         if (value == null) throw new CommandLineException($"Error: No value specified.");
 
+        // Validate and normalize the key against known settings
+        if (!KnownSettings.IsKnown(key))
+        {
+            var allKnownSettings = string.Join(", ", KnownSettings.GetAllKnownSettings().OrderBy(s => s));
+            throw new CommandLineException($"Error: Unknown setting '{key}'. Valid settings are: {allKnownSettings}");
+        }
+        
+        // Use the canonical form for storage
+        key = KnownSettings.GetCanonicalForm(key);
+
         // Try to parse as a list if the value is enclosed in brackets
         if (value.StartsWith("[") && value.EndsWith("]"))
         {

--- a/src/cycod/CommandLineCommands/ConfigCommands/ConfigSetCommand.cs
+++ b/src/cycod/CommandLineCommands/ConfigCommands/ConfigSetCommand.cs
@@ -32,11 +32,14 @@ class ConfigSetCommand : ConfigBaseCommand
         if (!KnownSettings.IsKnown(key))
         {
             var allKnownSettings = string.Join(", ", KnownSettings.GetAllKnownSettings().OrderBy(s => s));
-            throw new CommandLineException($"Error: Unknown setting '{key}'. Valid settings are: {allKnownSettings}");
+            Console.WriteLine($"Warning: Unknown setting '{key}'. Valid settings are: {allKnownSettings}");
+            // Continue with the original key without normalization
         }
-        
-        // Use the canonical form for storage
-        key = KnownSettings.GetCanonicalForm(key);
+        else
+        {
+            // Use the canonical form for storage of known settings
+            key = KnownSettings.GetCanonicalForm(key);
+        }
 
         // Try to parse as a list if the value is enclosed in brackets
         if (value.StartsWith("[") && value.EndsWith("]"))

--- a/tests/cycod-yaml/cycod-config-tests.yaml
+++ b/tests/cycod-yaml/cycod-config-tests.yaml
@@ -76,3 +76,18 @@
     expect-regex: |
       NonexistentKey: \(not found or empty\)
 
+  - name: Config Set creates correct casing
+    run: cycod config set openai.apiKey 1234567890 --local
+    expect-regex: |
+      LOCATION: .*[\\/]\.cycod[\\/]config(\.yaml){0,1} \(local\)
+      OpenAI.ApiKey: 12
+
+  - name: Config Get creates correct casing
+    run: cycod config get openai.apiKey --local
+    expect-regex: |
+      OpenAI.ApiKey: 12
+
+  - name: Config Clear creates correct casing
+    run: cycod config clear openai.apiKey --local
+    expect-regex: |
+      OpenAI.ApiKey: \(cleared\)


### PR DESCRIPTION
The set command is now storing KnownSettings in the canonical casing format:

Before: 
> cycod config set openai.apiKey --> stored as **openai.apiKey**  

After:
> cycod config set openai.apiKey --> stored as **OpenAI.ApiKey**  

The previous behavior caused the rest of the code to not find this setting and therefore the chat command for example would fail.

Any TestKey / TestValue set command will now create a warning letting the user know that they are not creating a KnownSetting (in case they have a typo), but will add the setting as before.

Added 3 tests for this new case as well.

NOTE: We might want to update our documentation so that the examples match the KnownSettings casing (for the openai case).