### PR TITLE
Improve command line input on non-Windows platforms with ReadLine library

### DIFF
--- a/src/cycod/CommandLineCommands/ChatCommand.cs
+++ b/src/cycod/CommandLineCommands/ChatCommand.cs
@@ -463,7 +463,30 @@ public class ChatCommand : CommandWithVariables
         var input = ReadLineOrSimulateInput(inputInstructions, null);
         if (input != null) return input;
 
+        var readLineNormally = OS.IsWindows();
+        return readLineNormally ?
+            InteractivelyReadLineNormally(defaultOnEndOfInput) :
+            InteractivelyReadLineWithReadLineLibrary(defaultOnEndOfInput);
+    }
+
+    private string? InteractivelyReadLineNormally(string? defaultOnEndOfInput)
+    {
         return Console.ReadLine() ?? defaultOnEndOfInput;
+    }
+
+    private string? InteractivelyReadLineWithReadLineLibrary(string? defaultOnEndOfInput)
+    {
+        var input = ReadLine.Read("", defaultOnEndOfInput);
+
+        var checkAddToHistory = !string.IsNullOrWhiteSpace(input);
+        if (checkAddToHistory)
+        {
+            var history = ReadLine.GetHistory();
+            var addToHistory = history.Count == 0 || history[history.Count - 1] != input;
+            if (addToHistory) ReadLine.AddHistory(input);
+        }
+
+        return input;
     }
 
     private void HandleUpdateMessages(IList<ChatMessage> messages)

--- a/src/cycod/cycod.csproj
+++ b/src/cycod/cycod.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.5.0-preview.1.25265.7" />
     <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.1" />
+    <PackageReference Include="ReadLine" Version="2.0.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />


### PR DESCRIPTION
## Overview
This PR enhances the terminal input experience for non-Windows users by integrating the ReadLine library.

## Details
- Added ReadLine NuGet package (2.0.1)
- Added specialized input handling for non-Windows platforms
- Includes command history management for non-Windows terminals

## Why
Windows Console.ReadLine provides a better interactive experience than the default readline behavior on non-Windows platforms. This change brings parity to the command line experience across operating systems by leveraging the ReadLine library for Linux/Mac users.

## Testing
Tested on Windows (no change in behavior) and non-Windows platforms (improved input experience with command history)