### PR TITLE
Add multiline input support in Chat Mode using backtick code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Chat Mode:
+  - Added support for multiline input using backtick code blocks
+  - Users can now paste multiline content by starting with three or more backticks and ending with a matching number of backticks
+
 ### Fixed
 - GitHub Copilot integration: Fixed token expiration issue by implementing automatic token refresh
   - Tokens are now automatically refreshed before they expire

--- a/src/common/Helpers/MultilineInputHelper.cs
+++ b/src/common/Helpers/MultilineInputHelper.cs
@@ -1,0 +1,80 @@
+/// <summary>
+/// Helper class for handling multiline input with backtick code blocks.
+/// </summary>
+public static class MultilineInputHelper
+{
+    /// <summary>
+    /// Reads multiline input from the console when a line starts with backticks.
+    /// </summary>
+    /// <param name="firstLine">The first line read, which should start with backticks.</param>
+    /// <returns>The content between matching backtick markers.</returns>
+    public static string ReadMultilineInput(string firstLine)
+    {
+        // Count the backticks at the start of the line
+        int backtickCount = CountLeadingBackticks(firstLine);
+        
+        // If there aren't at least 3 backticks, return the original line
+        if (backtickCount < 3)
+        {
+            return firstLine;
+        }
+        
+        // Store the content after the backticks from the first line
+        var builder = new System.Text.StringBuilder();
+        string contentAfterBackticks = firstLine.Substring(backtickCount);
+        
+        // Add the content after backticks from the first line (if not empty)
+        if (!string.IsNullOrEmpty(contentAfterBackticks))
+        {
+            builder.AppendLine(contentAfterBackticks);
+        }
+        
+        // Read additional lines until we find a matching closing backtick
+        string? line;
+        while ((line = Console.ReadLine()) != null)
+        {
+            // Check if this line has the matching number of backticks at the start
+            if (CountLeadingBackticks(line) == backtickCount && line.Trim() == new string('`', backtickCount))
+            {
+                // Closing backtick pattern found, exit the loop
+                break;
+            }
+            
+            // Add the line to our content
+            builder.AppendLine(line);
+        }
+        
+        return builder.ToString().TrimEnd();
+    }
+    
+    /// <summary>
+    /// Counts the number of backtick characters at the start of a string.
+    /// </summary>
+    /// <param name="line">The line to check.</param>
+    /// <returns>The number of consecutive backticks at the start of the line.</returns>
+    private static int CountLeadingBackticks(string line)
+    {
+        if (string.IsNullOrEmpty(line))
+        {
+            return 0;
+        }
+        
+        int count = 0;
+        while (count < line.Length && line[count] == '`')
+        {
+            count++;
+        }
+        
+        return count;
+    }
+    
+    /// <summary>
+    /// Checks if a line starts with at least 3 backticks.
+    /// </summary>
+    /// <param name="line">The line to check.</param>
+    /// <returns>True if the line starts with at least 3 backticks, false otherwise.</returns>
+    public static bool StartsWithBackticks(string line)
+    {
+        return !string.IsNullOrEmpty(line) && CountLeadingBackticks(line) >= 3;
+    }
+}

--- a/src/cycod/CommandLineCommands/ChatCommand.cs
+++ b/src/cycod/CommandLineCommands/ChatCommand.cs
@@ -463,7 +463,17 @@ public class ChatCommand : CommandWithVariables
         var input = ReadLineOrSimulateInput(inputInstructions, null);
         if (input != null) return input;
 
-        return Console.ReadLine() ?? defaultOnEndOfInput;
+        string? line = Console.ReadLine();
+        if (line == null) return defaultOnEndOfInput;
+
+        var isMultiLine = MultilineInputHelper.StartsWithBackticks(line);
+        return isMultiLine ? InteractivelyReadMultiLineInput(line) : line;
+    }
+
+    private string? InteractivelyReadMultiLineInput(string firstLine)    
+    {
+        ConsoleHelpers.WriteLine("Entering multiline mode. Enter a matching number of backticks on a line by itself to end.", ConsoleColor.DarkGray);
+        return MultilineInputHelper.ReadMultilineInput(firstLine);
     }
 
     private void HandleUpdateMessages(IList<ChatMessage> messages)

--- a/tests/cycod/MultilineInputHelperTests.cs
+++ b/tests/cycod/MultilineInputHelperTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class MultilineInputHelperTests
+{
+    [TestMethod]
+    public void StartsWithBackticks_ValidBackticks_ReturnsTrue()
+    {
+        // Arrange
+        string input = "```code block";
+        
+        // Act
+        bool result = MultilineInputHelper.StartsWithBackticks(input);
+        
+        // Assert
+        Assert.IsTrue(result);
+    }
+    
+    [TestMethod]
+    public void StartsWithBackticks_NotEnoughBackticks_ReturnsFalse()
+    {
+        // Arrange
+        string input = "``code block";
+        
+        // Act
+        bool result = MultilineInputHelper.StartsWithBackticks(input);
+        
+        // Assert
+        Assert.IsFalse(result);
+    }
+    
+    [TestMethod]
+    public void StartsWithBackticks_NoBackticks_ReturnsFalse()
+    {
+        // Arrange
+        string input = "code block";
+        
+        // Act
+        bool result = MultilineInputHelper.StartsWithBackticks(input);
+        
+        // Assert
+        Assert.IsFalse(result);
+    }
+    
+    [TestMethod]
+    public void StartsWithBackticks_NullInput_ReturnsFalse()
+    {
+        // Arrange
+        string? input = null;
+        
+        // Act
+        bool result = MultilineInputHelper.StartsWithBackticks(input!);
+        
+        // Assert
+        Assert.IsFalse(result);
+    }
+    
+    // Note: Testing ReadMultilineInput is more complex as it involves Console.ReadLine
+    // and would require mocking the console input
+}

--- a/tests/cycod/MultilineInputHelperTests.cs
+++ b/tests/cycod/MultilineInputHelperTests.cs
@@ -49,7 +49,7 @@ public class MultilineInputHelperTests
         string? input = null;
         
         // Act
-        bool result = MultilineInputHelper.StartsWithBackticks(input!);
+        bool result = MultilineInputHelper.StartsWithBackticks(input);
         
         // Assert
         Assert.IsFalse(result);


### PR DESCRIPTION
## Description

This PR adds support for multiline input in Chat Mode using backtick code blocks. Users can now paste multiline content by starting with three or more backticks and ending with a matching number of backticks.

## Changes
- Added new MultilineInputHelper class to handle detection and processing of backtick-delimited blocks
- Modified ChatCommand.cs to check for backtick-prefixed lines and process them accordingly
- Added clear user feedback when entering multiline mode
- Added tests for the backtick detection functionality

## Testing
- Unit tests have been added for the backtick detection functionality
- Manually tested by entering multiline content with backticks in the chat mode