### PR TITLE
Replace direct Console calls with ConsoleHelpers methods

### DIFF
--- a/src/common/Helpers/ConsoleHelpers.cs
+++ b/src/common/Helpers/ConsoleHelpers.cs
@@ -170,6 +170,11 @@ public class ConsoleHelpers
             : _allLinesFromStdin;
     }
 
+    public static void SetForegroundColor(ConsoleColor color)
+    {
+        Console.ForegroundColor = ColorHelpers.MapColor(color);
+    }
+
     public static ConsoleKeyInfo? ReadKey(bool intercept = false)
     {
         if (Console.IsInputRedirected)

--- a/src/cycod/CommandLineCommands/ChatCommand.cs
+++ b/src/cycod/CommandLineCommands/ChatCommand.cs
@@ -491,7 +491,7 @@ public class ChatCommand : CommandWithVariables
         }
         catch (Exception ex)
         {
-            ConsoleHelpers.WriteWarningLine($"Failed to save chat history to '{filePath}': {ex.Message}");
+            ConsoleHelpers.WriteWarningLine($"Warning: Failed to save chat history to '{filePath}': {ex.Message}");
         }
     }
 

--- a/src/cycod/CommandLineCommands/ChatCommand.cs
+++ b/src/cycod/CommandLineCommands/ChatCommand.cs
@@ -491,7 +491,7 @@ public class ChatCommand : CommandWithVariables
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Warning: Failed to save chat history to '{filePath}': {ex.Message}");
+            ConsoleHelpers.WriteWarningLine($"Failed to save chat history to '{filePath}': {ex.Message}");
         }
     }
 
@@ -589,7 +589,7 @@ public class ChatCommand : CommandWithVariables
     private void DisplayUserPrompt()
     {
         ConsoleHelpers.Write("\rUser: ", ConsoleColor.Green);
-        Console.ForegroundColor = ConsoleColor.White;
+        ConsoleHelpers.SetForegroundColor(ConsoleColor.White);
     }
 
     private void DisplayUserFunctionCall(string userFunctionName, string? result)


### PR DESCRIPTION
- Add SetForegroundColor method to ConsoleHelpers for color management
- Replace Console.ForegroundColor assignment in DisplayUserPrompt with ConsoleHelpers.SetForegroundColor
- Replace direct Console.WriteLine warning with ConsoleHelpers.WriteWarningLine in TrySaveChatHistoryToFile

Improves consistency by centralizing all console operations through the ConsoleHelpers abstraction layer.
