### PR TITLE
Fix: Restore auto-save logging default to true for backward compatibility

### DIFF
--- a/src/common/Logger/LoggingInitializer.cs
+++ b/src/common/Logger/LoggingInitializer.cs
@@ -90,7 +90,9 @@ public static class LoggingInitializer
     /// <returns>The grounded auto-save filename, or null if auto-save is disabled</returns>
     public static string? GroundAutoSaveLogFileName()
     {
-        var shouldAutoSave = ConfigStore.Instance.GetFromAnyScope(KnownSettings.AppAutoSaveLog).AsBool(false);
+        // Keep true as the default for backward compatibility with tests
+        // Applications can disable auto-save by setting AppAutoSaveLog to false in configuration
+        var shouldAutoSave = ConfigStore.Instance.GetFromAnyScope(KnownSettings.AppAutoSaveLog).AsBool(true);
         return shouldAutoSave ? FileHelpers.GetFileNameFromTemplate("log.log", DefaultLogFileNameTemplate) : null;
     }
 


### PR DESCRIPTION
Restored the default auto-save logging setting to true for backward compatibility with existing tests. Added comments to explain the change.